### PR TITLE
fix(ui): disable 'copy to clipboard' button in launcher

### DIFF
--- a/ui/src/emergence/emergence/CloneManagerShareDialog.svelte
+++ b/ui/src/emergence/emergence/CloneManagerShareDialog.svelte
@@ -26,12 +26,14 @@
     <p>Share this code with a friend to grant them access to the Network <b>{cellName}</b></p>
     <sl-textarea rows="2" style="margin-top: 10px;" value={joiningCode}></sl-textarea>
     <div style="display: flex; justify-content: flex-end; align-items: center">
-      <sl-button style="margin-top: 10px;" on:keydown={copyJoiningCode} on:click={copyJoiningCode}>
-        <div style="display: flex; justify-content: flex-start; align-items: center;">
-          <SvgIcon icon="faClone" size="16px"/>
-          <div style="margin-left: 10px;">Copy Joining Code</div>
-        </div>
-      </sl-button>
+      {#if navigator.clipboard !== undefined}
+        <sl-button style="margin-top: 10px;" on:keydown={copyJoiningCode} on:click={copyJoiningCode}>
+          <div style="display: flex; justify-content: flex-start; align-items: center;">
+            <SvgIcon icon="faClone" size="16px"/>
+            <div style="margin-left: 10px;">Copy Joining Code</div>
+          </div>
+        </sl-button>
+      {/if}
     </div>
   </div>
 </sl-dialog>


### PR DESCRIPTION
navigator.clipboard is undefined within the happ window in launcher (see https://github.com/holochain/launcher/issues/192)

This just removes the "copy to clipboard" button in contexts where it won't work.